### PR TITLE
Top and Bottom textfields auto cap and auto delete

### DIFF
--- a/MemeMe/MemeMe/Base.lproj/Main.storyboard
+++ b/MemeMe/MemeMe/Base.lproj/Main.storyboard
@@ -85,12 +85,15 @@
                                     <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGH-ia-BZA" userLabel="Editor Container View">
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eMz-CG-ltx" userLabel="Meme Imageview"/>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="TOP" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6OM-lI-SOW" userLabel="Top Textfield">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="TOP" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6OM-lI-SOW" userLabel="Top Textfield">
                                                 <rect key="frame" x="-47" y="10" width="95" height="53"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="44"/>
                                                 <textInputTraits key="textInputTraits"/>
+                                                <variation key="heightClass=compact" misplaced="YES">
+                                                    <rect key="frame" x="1" y="10" width="600" height="53"/>
+                                                </variation>
                                             </textField>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="BOTTOM" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ChD-Qm-4la" userLabel="Bottom Textfield">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="BOTTOM" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ChD-Qm-4la" userLabel="Bottom Textfield">
                                                 <rect key="frame" x="-99" y="-63" width="198" height="53"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="44"/>
                                                 <textInputTraits key="textInputTraits"/>

--- a/MemeMe/MemeMe/EditorViewController.swift
+++ b/MemeMe/MemeMe/EditorViewController.swift
@@ -32,6 +32,13 @@ class EditorViewController: UIViewController {
         }
 
         createTapRecognizerForKeyboardDismiss()
+
+        // Auto caps on the textfields
+        topTextField.autocapitalizationType = .AllCharacters
+        bottomTextField.autocapitalizationType = .AllCharacters
+
+        topTextField.delegate = self
+        bottomTextField.delegate = self
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -211,6 +218,16 @@ extension EditorViewController: UIImagePickerControllerDelegate {
 }
 
 extension EditorViewController: UINavigationControllerDelegate {
+
+}
+
+extension EditorViewController: UITextFieldDelegate {
+
+    func textFieldShouldBeginEditing(textField: UITextField) -> Bool {
+        // We want to remove all text when the user taps on the textfield
+        textField.text = ""
+        return true
+    }
 
 }
 


### PR DESCRIPTION
## What is this?

The text on top and bottom didn't default to all caps, and it didn't auto-delete when you tapped on the textfields
## What did I do?
- Made the EditorViewController the delegate for both textfields, and that makes sure that they clear on tap.
- Set the autocapitalizationtype to AllCaps on both textfields
- The TOP and BOTTOM text that initially gets set was not a placeholder, so it wouldn't come back if I edited the textfield and left it empty. Those are now placeholders, so they do come back.
## Related Issues
#9 Auto Capitalize Text
#10 Auto Delete Text
