### PR TITLE
Pressing cancel button clears all text and image

### DIFF
--- a/MemeMe/MemeMe/EditorViewController.swift
+++ b/MemeMe/MemeMe/EditorViewController.swift
@@ -204,8 +204,16 @@ class EditorViewController: UIViewController {
         }
     }
 
-    @IBAction func tappedCancelButton(sender: UIBarButtonItem) {
+    /**
+     Causes the Meme Editor View to return to its launch state, 
+     displaying no image and default text.
 
+     - parameter sender: UIBarButtonItem
+     */
+    @IBAction func tappedCancelButton(sender: UIBarButtonItem) {
+        topTextField.text = ""
+        bottomTextField.text = ""
+        imageView.image = nil
     }
     
 }


### PR DESCRIPTION
## What is this?

The cancel button did nothing, but the specs from Udacity say that 
"When the user presses the “Cancel” button, the Meme Editor View returns to its launch state, displaying no image and default text."
## What did I do?

The cancel button now clears all text and image
