### PR TITLE
Crop images - pinch to zoom

### DIFF
--- a/MemeMe/MemeMe/Base.lproj/Main.storyboard
+++ b/MemeMe/MemeMe/Base.lproj/Main.storyboard
@@ -102,13 +102,16 @@
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eMz-CG-ltx" userLabel="Meme Imageview">
                                                         <rect key="frame" x="120" y="64" width="0.0" height="0.0"/>
+                                                        <variation key="heightClass=compact" ambiguous="YES" misplaced="YES">
+                                                            <rect key="frame" x="0.0" y="0.0" width="520" height="292"/>
+                                                        </variation>
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="eMz-CG-ltx" firstAttribute="height" secondItem="L6b-ts-V5Q" secondAttribute="height" id="FZd-OR-ERf"/>
                                                     <constraint firstItem="eMz-CG-ltx" firstAttribute="width" secondItem="L6b-ts-V5Q" secondAttribute="width" id="Fkm-pg-S1U"/>
                                                     <constraint firstItem="eMz-CG-ltx" firstAttribute="centerX" secondItem="L6b-ts-V5Q" secondAttribute="centerX" id="PyS-Ws-gqO"/>
-                                                    <constraint firstAttribute="width" secondItem="L6b-ts-V5Q" secondAttribute="height" multiplier="16:9" id="gXQ-Qk-ydG"/>
+                                                    <constraint firstAttribute="width" secondItem="L6b-ts-V5Q" secondAttribute="height" multiplier="13:9" id="gXQ-Qk-ydG"/>
                                                     <constraint firstItem="eMz-CG-ltx" firstAttribute="centerY" secondItem="L6b-ts-V5Q" secondAttribute="centerY" id="wtC-Ma-PS9"/>
                                                 </constraints>
                                                 <variation key="default">
@@ -116,10 +119,11 @@
                                                         <exclude reference="gXQ-Qk-ydG"/>
                                                     </mask>
                                                 </variation>
-                                                <variation key="heightClass=compact" ambiguous="YES">
+                                                <variation key="heightClass=compact" ambiguous="YES" misplaced="YES">
                                                     <rect key="frame" x="40" y="0.0" width="520" height="292"/>
                                                     <mask key="constraints">
                                                         <include reference="gXQ-Qk-ydG"/>
+                                                        <exclude reference="Fkm-pg-S1U"/>
                                                     </mask>
                                                 </variation>
                                             </scrollView>

--- a/MemeMe/MemeMe/Base.lproj/Main.storyboard
+++ b/MemeMe/MemeMe/Base.lproj/Main.storyboard
@@ -111,7 +111,7 @@
                                                     <constraint firstItem="eMz-CG-ltx" firstAttribute="height" secondItem="L6b-ts-V5Q" secondAttribute="height" id="FZd-OR-ERf"/>
                                                     <constraint firstItem="eMz-CG-ltx" firstAttribute="width" secondItem="L6b-ts-V5Q" secondAttribute="width" id="Fkm-pg-S1U"/>
                                                     <constraint firstItem="eMz-CG-ltx" firstAttribute="centerX" secondItem="L6b-ts-V5Q" secondAttribute="centerX" id="PyS-Ws-gqO"/>
-                                                    <constraint firstAttribute="width" secondItem="L6b-ts-V5Q" secondAttribute="height" multiplier="13:9" id="gXQ-Qk-ydG"/>
+                                                    <constraint firstAttribute="width" secondItem="L6b-ts-V5Q" secondAttribute="height" multiplier="16:9" id="gXQ-Qk-ydG"/>
                                                     <constraint firstItem="eMz-CG-ltx" firstAttribute="centerY" secondItem="L6b-ts-V5Q" secondAttribute="centerY" id="wtC-Ma-PS9"/>
                                                 </constraints>
                                                 <variation key="default">
@@ -122,10 +122,13 @@
                                                 <variation key="heightClass=compact" ambiguous="YES" misplaced="YES">
                                                     <rect key="frame" x="40" y="0.0" width="520" height="292"/>
                                                     <mask key="constraints">
-                                                        <include reference="gXQ-Qk-ydG"/>
+                                                        <exclude reference="gXQ-Qk-ydG"/>
                                                         <exclude reference="Fkm-pg-S1U"/>
                                                     </mask>
                                                 </variation>
+                                                <connections>
+                                                    <outlet property="delegate" destination="BYZ-38-t0r" id="V5Y-41-iBN"/>
+                                                </connections>
                                             </scrollView>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" usesAttributedText="YES" allowsEditingTextAttributes="YES" placeholder="TOP" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6OM-lI-SOW" userLabel="Top Textfield">
                                                 <rect key="frame" x="-47" y="10" width="95" height="53"/>
@@ -147,6 +150,7 @@
                                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstItem="ChD-Qm-4la" firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="width" id="1Lp-6Q-tqb"/>
+                                            <constraint firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="height" multiplier="13:9" id="1bQ-Bd-tZQ"/>
                                             <constraint firstItem="ChD-Qm-4la" firstAttribute="centerX" secondItem="pGH-ia-BZA" secondAttribute="centerX" id="1mu-mo-kxV"/>
                                             <constraint firstItem="L6b-ts-V5Q" firstAttribute="height" secondItem="pGH-ia-BZA" secondAttribute="height" id="2A4-Fu-Xxy"/>
                                             <constraint firstAttribute="bottom" secondItem="ChD-Qm-4la" secondAttribute="bottom" constant="10" id="37V-lh-Rdf"/>
@@ -155,6 +159,7 @@
                                             <constraint firstItem="L6b-ts-V5Q" firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="width" id="CJP-yj-bgl"/>
                                             <constraint firstItem="L6b-ts-V5Q" firstAttribute="centerX" secondItem="pGH-ia-BZA" secondAttribute="centerX" id="D0S-fh-ewR"/>
                                             <constraint firstItem="L6b-ts-V5Q" firstAttribute="centerY" secondItem="pGH-ia-BZA" secondAttribute="centerY" id="Nuw-Jb-OqE"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="width" id="Zy5-bX-ybS"/>
                                             <constraint firstItem="L6b-ts-V5Q" firstAttribute="centerX" secondItem="pGH-ia-BZA" secondAttribute="centerX" id="iOM-oB-vCI"/>
                                             <constraint firstItem="6OM-lI-SOW" firstAttribute="top" secondItem="pGH-ia-BZA" secondAttribute="top" constant="10" id="ker-3w-hhF"/>
                                             <constraint firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="height" multiplier="16:9" id="lZY-jn-Ly3"/>
@@ -165,6 +170,7 @@
                                         </constraints>
                                         <variation key="default">
                                             <mask key="constraints">
+                                                <exclude reference="1bQ-Bd-tZQ"/>
                                                 <exclude reference="BBq-pp-l0w"/>
                                                 <exclude reference="lZY-jn-Ly3"/>
                                                 <exclude reference="2A4-Fu-Xxy"/>
@@ -172,6 +178,7 @@
                                                 <exclude reference="CJP-yj-bgl"/>
                                                 <exclude reference="D0S-fh-ewR"/>
                                                 <exclude reference="Nuw-Jb-OqE"/>
+                                                <exclude reference="Zy5-bX-ybS"/>
                                                 <exclude reference="iOM-oB-vCI"/>
                                                 <exclude reference="mtL-zW-cDv"/>
                                                 <exclude reference="ubt-d8-Fw9"/>
@@ -179,9 +186,11 @@
                                         </variation>
                                         <variation key="heightClass=compact">
                                             <mask key="constraints">
+                                                <include reference="1bQ-Bd-tZQ"/>
                                                 <exclude reference="lZY-jn-Ly3"/>
                                                 <include reference="2A4-Fu-Xxy"/>
                                                 <include reference="D0S-fh-ewR"/>
+                                                <include reference="Zy5-bX-ybS"/>
                                                 <include reference="mtL-zW-cDv"/>
                                                 <exclude reference="ubt-d8-Fw9"/>
                                             </mask>
@@ -214,7 +223,7 @@
                                 </variation>
                                 <variation key="heightClass=compact">
                                     <mask key="constraints">
-                                        <include reference="48L-p5-I6w"/>
+                                        <exclude reference="48L-p5-I6w"/>
                                         <include reference="Yg8-AX-wmf"/>
                                     </mask>
                                 </variation>
@@ -256,6 +265,7 @@
                         <outlet property="bottomToolbar" destination="iHp-gv-ty3" id="ril-RV-FdU"/>
                         <outlet property="editorContainer" destination="pGH-ia-BZA" id="yP7-RR-fGa"/>
                         <outlet property="imageView" destination="eMz-CG-ltx" id="kbq-mY-Omc"/>
+                        <outlet property="scrollView" destination="L6b-ts-V5Q" id="KWy-Ha-lDS"/>
                         <outlet property="topTextField" destination="6OM-lI-SOW" id="deo-rx-d28"/>
                         <outlet property="topToolbar" destination="23E-Q8-qh1" id="1gd-RP-F9Y"/>
                     </connections>

--- a/MemeMe/MemeMe/Base.lproj/Main.storyboard
+++ b/MemeMe/MemeMe/Base.lproj/Main.storyboard
@@ -97,14 +97,36 @@
                                 <subviews>
                                     <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pGH-ia-BZA" userLabel="Editor Container View">
                                         <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eMz-CG-ltx" userLabel="Meme Imageview"/>
+                                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L6b-ts-V5Q">
+                                                <rect key="frame" x="-120" y="-64" width="240" height="128"/>
+                                                <subviews>
+                                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eMz-CG-ltx" userLabel="Meme Imageview">
+                                                        <rect key="frame" x="120" y="64" width="0.0" height="0.0"/>
+                                                    </imageView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="eMz-CG-ltx" firstAttribute="height" secondItem="L6b-ts-V5Q" secondAttribute="height" id="FZd-OR-ERf"/>
+                                                    <constraint firstItem="eMz-CG-ltx" firstAttribute="width" secondItem="L6b-ts-V5Q" secondAttribute="width" id="Fkm-pg-S1U"/>
+                                                    <constraint firstItem="eMz-CG-ltx" firstAttribute="centerX" secondItem="L6b-ts-V5Q" secondAttribute="centerX" id="PyS-Ws-gqO"/>
+                                                    <constraint firstAttribute="width" secondItem="L6b-ts-V5Q" secondAttribute="height" multiplier="16:9" id="gXQ-Qk-ydG"/>
+                                                    <constraint firstItem="eMz-CG-ltx" firstAttribute="centerY" secondItem="L6b-ts-V5Q" secondAttribute="centerY" id="wtC-Ma-PS9"/>
+                                                </constraints>
+                                                <variation key="default">
+                                                    <mask key="constraints">
+                                                        <exclude reference="gXQ-Qk-ydG"/>
+                                                    </mask>
+                                                </variation>
+                                                <variation key="heightClass=compact" ambiguous="YES">
+                                                    <rect key="frame" x="40" y="0.0" width="520" height="292"/>
+                                                    <mask key="constraints">
+                                                        <include reference="gXQ-Qk-ydG"/>
+                                                    </mask>
+                                                </variation>
+                                            </scrollView>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" usesAttributedText="YES" allowsEditingTextAttributes="YES" placeholder="TOP" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6OM-lI-SOW" userLabel="Top Textfield">
                                                 <rect key="frame" x="-47" y="10" width="95" height="53"/>
                                                 <attributedString key="attributedText"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters" autocorrectionType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
-                                                <variation key="heightClass=compact" misplaced="YES">
-                                                    <rect key="frame" x="1" y="10" width="600" height="53"/>
-                                                </variation>
                                                 <variation key="heightClass=regular-widthClass=compact" misplaced="YES">
                                                     <rect key="frame" x="1" y="10" width="400" height="54"/>
                                                 </variation>
@@ -113,9 +135,6 @@
                                                 <rect key="frame" x="-99" y="-63" width="198" height="53"/>
                                                 <attributedString key="attributedText"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters" autocorrectionType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
-                                                <variation key="heightClass=compact" misplaced="YES">
-                                                    <rect key="frame" x="0.0" y="229" width="600" height="53"/>
-                                                </variation>
                                                 <variation key="heightClass=regular-widthClass=compact" misplaced="YES">
                                                     <rect key="frame" x="0.0" y="336" width="400" height="54"/>
                                                 </variation>
@@ -125,31 +144,51 @@
                                         <constraints>
                                             <constraint firstItem="ChD-Qm-4la" firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="width" id="1Lp-6Q-tqb"/>
                                             <constraint firstItem="ChD-Qm-4la" firstAttribute="centerX" secondItem="pGH-ia-BZA" secondAttribute="centerX" id="1mu-mo-kxV"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="height" secondItem="pGH-ia-BZA" secondAttribute="height" id="2A4-Fu-Xxy"/>
                                             <constraint firstAttribute="bottom" secondItem="ChD-Qm-4la" secondAttribute="bottom" constant="10" id="37V-lh-Rdf"/>
-                                            <constraint firstItem="eMz-CG-ltx" firstAttribute="centerX" secondItem="pGH-ia-BZA" secondAttribute="centerX" id="7ge-uH-1U2"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="height" secondItem="pGH-ia-BZA" secondAttribute="height" id="8eW-wd-82g"/>
                                             <constraint firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="height" multiplier="1:1" id="BBq-pp-l0w"/>
-                                            <constraint firstItem="eMz-CG-ltx" firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="width" id="HR7-ka-Eof"/>
-                                            <constraint firstItem="eMz-CG-ltx" firstAttribute="height" secondItem="pGH-ia-BZA" secondAttribute="height" id="Roh-hs-4A8"/>
-                                            <constraint firstItem="eMz-CG-ltx" firstAttribute="centerY" secondItem="pGH-ia-BZA" secondAttribute="centerY" id="bfL-Ob-ggg"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="width" id="CJP-yj-bgl"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="centerX" secondItem="pGH-ia-BZA" secondAttribute="centerX" id="D0S-fh-ewR"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="centerY" secondItem="pGH-ia-BZA" secondAttribute="centerY" id="Nuw-Jb-OqE"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="centerX" secondItem="pGH-ia-BZA" secondAttribute="centerX" id="iOM-oB-vCI"/>
                                             <constraint firstItem="6OM-lI-SOW" firstAttribute="top" secondItem="pGH-ia-BZA" secondAttribute="top" constant="10" id="ker-3w-hhF"/>
                                             <constraint firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="height" multiplier="16:9" id="lZY-jn-Ly3"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="centerY" secondItem="pGH-ia-BZA" secondAttribute="centerY" id="mtL-zW-cDv"/>
                                             <constraint firstItem="6OM-lI-SOW" firstAttribute="centerX" secondItem="pGH-ia-BZA" secondAttribute="centerX" id="olN-j0-FrU"/>
                                             <constraint firstItem="6OM-lI-SOW" firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="width" id="u7x-TQ-wfn"/>
+                                            <constraint firstItem="L6b-ts-V5Q" firstAttribute="width" secondItem="pGH-ia-BZA" secondAttribute="width" id="ubt-d8-Fw9"/>
                                         </constraints>
                                         <variation key="default">
                                             <mask key="constraints">
                                                 <exclude reference="BBq-pp-l0w"/>
                                                 <exclude reference="lZY-jn-Ly3"/>
+                                                <exclude reference="2A4-Fu-Xxy"/>
+                                                <exclude reference="8eW-wd-82g"/>
+                                                <exclude reference="CJP-yj-bgl"/>
+                                                <exclude reference="D0S-fh-ewR"/>
+                                                <exclude reference="Nuw-Jb-OqE"/>
+                                                <exclude reference="iOM-oB-vCI"/>
+                                                <exclude reference="mtL-zW-cDv"/>
+                                                <exclude reference="ubt-d8-Fw9"/>
                                             </mask>
                                         </variation>
                                         <variation key="heightClass=compact">
                                             <mask key="constraints">
                                                 <exclude reference="lZY-jn-Ly3"/>
+                                                <include reference="2A4-Fu-Xxy"/>
+                                                <include reference="D0S-fh-ewR"/>
+                                                <include reference="mtL-zW-cDv"/>
+                                                <exclude reference="ubt-d8-Fw9"/>
                                             </mask>
                                         </variation>
                                         <variation key="heightClass=regular-widthClass=compact">
                                             <mask key="constraints">
                                                 <include reference="BBq-pp-l0w"/>
+                                                <include reference="8eW-wd-82g"/>
+                                                <include reference="CJP-yj-bgl"/>
+                                                <include reference="Nuw-Jb-OqE"/>
+                                                <include reference="iOM-oB-vCI"/>
                                             </mask>
                                         </variation>
                                     </view>

--- a/MemeMe/MemeMe/EditorViewController.swift
+++ b/MemeMe/MemeMe/EditorViewController.swift
@@ -23,6 +23,8 @@ class EditorViewController: UIViewController {
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var editorContainer: UIView!
 
+    @IBOutlet weak var scrollView: UIScrollView!
+
     var pickerController: UIImagePickerController? = nil
 
     override func viewDidLoad() {
@@ -53,6 +55,10 @@ class EditorViewController: UIViewController {
         // Add border around editor container
         editorContainer.layer.borderWidth = 2
         editorContainer.layer.borderColor = UIColor.whiteColor().CGColor
+
+        scrollView.minimumZoomScale=0.5;
+        scrollView.maximumZoomScale=6.0;
+        scrollView.delegate = self
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -289,6 +295,14 @@ extension EditorViewController: PopularMemePickerDelegate {
         print("Picked meme \(meme)")
         imageView.image = meme.image
     }
+}
+
+extension EditorViewController: UIScrollViewDelegate {
+
+    func viewForZoomingInScrollView(scrollView: UIScrollView) -> UIView? {
+        return self.imageView
+    }
+
 }
 
 extension EditorViewController: UINavigationControllerDelegate {

--- a/MemeMe/MemeMe/EditorViewController.swift
+++ b/MemeMe/MemeMe/EditorViewController.swift
@@ -49,6 +49,10 @@ class EditorViewController: UIViewController {
         bottomTextField.textAlignment = .Center
 
         pickerController = UIImagePickerController()
+
+        // Add border around editor container
+        editorContainer.layer.borderWidth = 2
+        editorContainer.layer.borderColor = UIColor.whiteColor().CGColor
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -127,12 +131,19 @@ class EditorViewController: UIViewController {
      */
     func generateMemedImage(view: UIView) -> UIImage
     {
+
+        // Remove any borders
+        let borderWidth = view.layer.borderWidth
+        view.layer.borderWidth = 0
+
         // Render view to an image
         UIGraphicsBeginImageContext(view.frame.size)
-        view.drawViewHierarchyInRect(view.bounds, afterScreenUpdates: false)
+        view.drawViewHierarchyInRect(view.bounds, afterScreenUpdates: true)
         let memedImage : UIImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()       
-        
+        UIGraphicsEndImageContext()
+
+        view.layer.borderWidth = borderWidth
+
         return memedImage
     }
 

--- a/MemeMe/MemeMe/EditorViewController.swift
+++ b/MemeMe/MemeMe/EditorViewController.swift
@@ -56,8 +56,8 @@ class EditorViewController: UIViewController {
         editorContainer.layer.borderWidth = 2
         editorContainer.layer.borderColor = UIColor.whiteColor().CGColor
 
-        scrollView.minimumZoomScale=0.5;
-        scrollView.maximumZoomScale=6.0;
+        scrollView.minimumZoomScale=0.5
+        scrollView.maximumZoomScale=6.0
         scrollView.delegate = self
     }
 


### PR DESCRIPTION
## What is this?

The user was not able to zoom into the meme images or crop them, so they were just stuck with however it showed up first.
## What did I do?

I made it so that the user can pinch to zoom, and place the image however he/she wants before saving. I also added a white box to define the region that the screenshot will take into account.

Another huge deal here is that landscape mode is now fixed! See pics below 
## Screenshots

![img_0089](https://cloud.githubusercontent.com/assets/5385681/18409198/ea18cd7a-770f-11e6-8b16-69cb73cfaebb.PNG)
![img_0088](https://cloud.githubusercontent.com/assets/5385681/18409199/ea18eaf8-770f-11e6-84d2-1fce74c8f53e.PNG)
![img_0087](https://cloud.githubusercontent.com/assets/5385681/18409200/ea192cac-770f-11e6-9447-cad55573993b.PNG)
![img_0086](https://cloud.githubusercontent.com/assets/5385681/18409201/ea193e2c-770f-11e6-8e9d-a4384d1042f2.PNG)
